### PR TITLE
Reduce PromiseKit dependencies

### DIFF
--- a/Dilbert Me/DilbertManager.m
+++ b/Dilbert Me/DilbertManager.m
@@ -70,25 +70,18 @@
 
 
 + (PMKPromise *)parseComic:(HTMLElement *)element {
-    return [PMKPromise new:^(PMKPromiseFulfiller fulfill, PMKPromiseRejecter reject) {
-        // get date
-        NSString *comicDateString = [[element firstNodeMatchingSelector:@"h3.comic-item-date span a date"] textContent];
-        NSDate *comicDate = [[YLMoment momentWithDateAsString:comicDateString] date];
-        
-        // get image
-        HTMLElement *todaysComicImgElement = [element firstNodeMatchingSelector:@"img.img-comic"];
-        NSString *todaysComicImageURL = [todaysComicImgElement attributes][@"src"];
-        
-        [AFHTTPRequestOperation request:[NSURLRequest requestWithURL:[NSURL URLWithString:todaysComicImageURL]]]
-        .then(^(id responseObject) {
-            NSImage *image = [[NSImage alloc] initWithData:responseObject];
-            Comic *comic = [[Comic alloc] initWithDate:comicDate image:image];
-            fulfill(comic);
-        })
-        .catch(^(NSError *error){
-            reject(error);
-        });
-    }];
+    NSString *comicDateString = [[element firstNodeMatchingSelector:@"h3.comic-item-date span a date"] textContent];
+    NSDate *comicDate = [[YLMoment momentWithDateAsString:comicDateString] date];
+    
+    // get image
+    HTMLElement *todaysComicImgElement = [element firstNodeMatchingSelector:@"img.img-comic"];
+    NSString *todaysComicImageURL = [todaysComicImgElement attributes][@"src"];
+    
+    return [AFHTTPRequestOperation request:[NSURLRequest requestWithURL:[NSURL URLWithString:todaysComicImageURL]]]
+    .then(^(id responseObject) {
+        NSImage *image = [[NSImage alloc] initWithData:responseObject];
+        return [[Comic alloc] initWithDate:comicDate image:image];
+    });
 }
 
 

--- a/Dilbert Me/DilbertMenu.m
+++ b/Dilbert Me/DilbertMenu.m
@@ -48,7 +48,7 @@
             [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:self];
             NSUserNotification *notification = [[NSUserNotification alloc] init];
             notification.title = @"Daily Dilbert";
-            notification.informativeText = @"There's a new Daily Dilbert";
+            notification.informativeText = @"There’s a new Daily Dilbert";
             notification.soundName = NSUserNotificationDefaultSoundName;
             [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
         }

--- a/Dilbert Me/DilbertMenu.xib
+++ b/Dilbert Me/DilbertMenu.xib
@@ -15,7 +15,7 @@
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
         <menu title="Hi there" autoenablesItems="NO" id="l5F-sZ-V2D">
             <items>
-                <menuItem title="Today's Dilbert" id="zzh-n8-DQa">
+                <menuItem title="Today’s Dilbert" id="zzh-n8-DQa">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="didPressTodaysDilbert:" target="-2" id="6Is-wf-3Jc"/>

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,8 @@ target 'Dilbert Me' do
 pod 'AFNetworking'
 pod 'Realm'
 pod 'HTMLReader'
-pod 'PromiseKit'
+pod 'PromiseKit/Promise'
+pod 'PromiseKit/When'
 pod 'PromiseKit-AFNetworking'
 pod 'YLMoment'
 end


### PR DESCRIPTION
Love the app, and noticed you were using PromiseKit. Thought I'd submit a PR that:

1) Reduces the amount of PromiseKit you use, since you were only using `PMKPromise` and `when`
2) Alters one of your promise utilizations slightly, since the use of new in that case was superfluous.
3) Changes two uses of `'` to `’` since technically this is more correct… :)

If you don't like any of these changes I can remove them from the PR. Thanks!
